### PR TITLE
10 query available beamlines

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,13 +109,13 @@ Get the visit directory for a beamline and visit
 }
 ```
 
-#### configuration
-Get the current configuration values for the given beamline
+#### configurations
+Get the current configuration values, optionally filtering for a specific beamline
 
 ##### Query
 ```graphql
 {
-  configuration(beamline: "i22") {
+  configurations(beamlineFilter: "i22") {
     visitTemplate
     scanTemplate
     detectorTemplate
@@ -127,12 +127,14 @@ Get the current configuration values for the given beamline
 ##### Response
 ```json
 {
-  "configuration": {
-    "visitTemplate": "/data/{instrument}/data/{year}/{visit}",
-    "scanTemplate": "{subdirectory}/{instrument}-{scan_number}",
-    "detectorTemplate": "{subdirectory}/{instrument}-{scan_number}-{detector}",
-    "latestScanNumber": 20839
-  }
+  "configurations": [
+    {
+      "visitTemplate": "/tmp/{instrument}/data/{year}/{visit}",
+      "scanTemplate": "{subdirectory}/{instrument}-{scan_number}",
+      "detectorTemplate": "{subdirectory}/{instrument}-{scan_number}-{detector}",
+      "latestScanNumber": 12345
+    }
+  ]
 }
 ```
 

--- a/src/db_service.rs
+++ b/src/db_service.rs
@@ -303,6 +303,15 @@ impl SqliteScanPathService {
         .ok_or(ConfigurationError::MissingBeamline(beamline.into()))
     }
 
+    pub async fn configurations(&self) -> Result<Vec<BeamlineConfiguration>, ConfigurationError> {
+        Ok(query_as!(DbBeamlineConfig, "SELECT * FROM beamline")
+            .fetch_all(&self.pool)
+            .await?
+            .into_iter()
+            .map(BeamlineConfiguration::from)
+            .collect())
+    }
+
     pub async fn next_scan_configuration(
         &self,
         beamline: &str,
@@ -583,6 +592,33 @@ mod db_tests {
     #[test]
     async fn current_configuration(#[future(awt)] db: SqliteScanPathService) {
         let conf = ok!(db.current_configuration("i22"));
+        assert_eq!(conf.name(), "i22");
+        assert_eq!(conf.scan_number(), 122);
+        assert_eq!(
+            conf.visit().unwrap().to_string(),
+            "/tmp/{instrument}/data/{year}/{visit}"
+        );
+        assert_eq!(
+            conf.scan().unwrap().to_string(),
+            "{subdirectory}/{instrument}-{scan_number}"
+        );
+        assert_eq!(
+            conf.detector().unwrap().to_string(),
+            "{subdirectory}/{instrument}-{scan_number}-{detector}"
+        );
+        let Some(fb) = conf.fallback() else {
+            panic!("Missing fallback configuration");
+        };
+        assert_eq!(fb.directory, "/tmp/trackers");
+        assert_eq!(fb.extension, "ext");
+    }
+
+    #[rstest]
+    #[test]
+    async fn configurations(#[future(awt)] db: SqliteScanPathService) {
+        let confs = ok!(db.configurations());
+        assert_eq!(confs.len(), 1);
+        let conf = confs.first().unwrap();
         assert_eq!(conf.name(), "i22");
         assert_eq!(conf.scan_number(), 122);
         assert_eq!(

--- a/src/db_service.rs
+++ b/src/db_service.rs
@@ -356,7 +356,7 @@ impl fmt::Debug for SqliteScanPathService {
     }
 }
 
-mod error {
+pub(crate) mod error {
     use std::error::Error;
     use std::fmt::{self, Display};
 

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -207,6 +207,10 @@ impl ScanPaths {
 
 #[Object]
 impl BeamlineConfiguration {
+    pub async fn instrument(&self) -> async_graphql::Result<String> {
+        Ok(self.name().to_owned())
+    }
+
     pub async fn visit_template(&self) -> async_graphql::Result<String> {
         Ok(self.visit()?.to_string())
     }


### PR DESCRIPTION
Fixes #10

Expand configuration query to be able to return multiple configurations. Change name to configurations. Make beamline parameter optional (and rename to beamlineFilter). When a filter is provided, only details for that beamline are returned, otherwise all beamline configurations are returned.

Expose the name of a configuration (which typically matches the name the beamline) in the GraphQL API. Now that we have a query that a list of configurations it is useful to have a field that differentiate between them.