### PR TITLE
Reduce the default PVC size in helm chart

### DIFF
--- a/helm/numtracker/values.yaml
+++ b/helm/numtracker/values.yaml
@@ -19,7 +19,7 @@ numtracker:
   storage:
     claimName: daq-numtracker-db-volume
     mount: /data
-    size: 50M
+    size: 5M
   tracing:
     enabled: false
     host: "https://jaeger.diamond.ac.uk"


### PR DESCRIPTION
It is very unlikely that the DB will ever reach more than a few kB so
defaulting to 50M was slightly excessive.
