### PR TITLE
Check directory file numbers when returning configuration

### DIFF
--- a/src/db_service.rs
+++ b/src/db_service.rs
@@ -89,13 +89,6 @@ impl BeamlineConfiguration {
     pub fn detector(&self) -> SqliteTemplateResult<DetectorField> {
         self.detector.as_template()
     }
-
-    pub fn with_scan_number(self, new_number: u32) -> Self {
-        Self {
-            scan_number: new_number,
-            ..self
-        }
-    }
 }
 
 impl<'r> FromRow<'r, SqliteRow> for BeamlineConfiguration {

--- a/src/db_service.rs
+++ b/src/db_service.rs
@@ -89,6 +89,13 @@ impl BeamlineConfiguration {
     pub fn detector(&self) -> SqliteTemplateResult<DetectorField> {
         self.detector.as_template()
     }
+
+    pub fn with_scan_number(self, new_number: u32) -> Self {
+        Self {
+            scan_number: new_number,
+            ..self
+        }
+    }
 }
 
 impl<'r> FromRow<'r, SqliteRow> for BeamlineConfiguration {

--- a/src/db_service.rs
+++ b/src/db_service.rs
@@ -66,7 +66,7 @@ pub struct BeamlineConfiguration {
     visit: RawPathTemplate<VisitTemplate>,
     scan: RawPathTemplate<ScanTemplate>,
     detector: RawPathTemplate<DetectorTemplate>,
-    pub(crate) tracker_file_extension: Option<String>,
+    tracker_file_extension: Option<String>,
 }
 
 impl BeamlineConfiguration {
@@ -88,6 +88,10 @@ impl BeamlineConfiguration {
 
     pub fn detector(&self) -> SqliteTemplateResult<DetectorField> {
         self.detector.as_template()
+    }
+
+    pub fn tracker_file_extension(&self) -> Option<&str> {
+        self.tracker_file_extension.as_deref()
     }
 }
 

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -376,14 +376,14 @@ impl Mutation {
     ) -> async_graphql::Result<CurrentConfiguration> {
         check_auth(ctx, |pc, token| pc.check_admin(token, &beamline)).await?;
         let db = ctx.data::<SqliteScanPathService>()?;
+        let nt = ctx.data::<NumTracker>()?;
         trace!("Configuring: {beamline}: {config:?}");
         let upd = config.into_update(&beamline);
         let db_config = match upd.update_beamline(db).await? {
             Some(bc) => bc,
             None => upd.insert_new(db).await?,
         };
-        let dir = ctx
-            .data::<NumTracker>()?
+        let dir = nt
             .for_beamline(&beamline, db_config.tracker_file_extension())
             .await?;
         let high_file = dir.prev().await?;

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -147,6 +147,12 @@ struct ScanPaths {
     subdirectory: Subdirectory,
 }
 
+/// GraphQL type to provide current configuration for a beamline
+struct CurrentConfiguration {
+    db_config: BeamlineConfiguration,
+    high_file: Option<u32>,
+}
+
 /// Error to be returned when a path contains non-unicode characters
 #[derive(Debug)]
 struct NonUnicodePath;
@@ -243,21 +249,24 @@ impl ScanPaths {
 }
 
 #[Object]
-impl BeamlineConfiguration {
+impl CurrentConfiguration {
     pub async fn visit_template(&self) -> async_graphql::Result<String> {
-        Ok(self.visit()?.to_string())
+        Ok(self.db_config.visit()?.to_string())
     }
     pub async fn scan_template(&self) -> async_graphql::Result<String> {
-        Ok(self.scan()?.to_string())
+        Ok(self.db_config.scan()?.to_string())
     }
     pub async fn detector_template(&self) -> async_graphql::Result<String> {
-        Ok(self.detector()?.to_string())
+        Ok(self.db_config.detector()?.to_string())
     }
-    pub async fn latest_scan_number(&self) -> async_graphql::Result<u32> {
-        Ok(self.scan_number())
+    pub async fn db_scan_number(&self) -> async_graphql::Result<u32> {
+        Ok(self.db_config.scan_number())
+    }
+    pub async fn file_scan_number(&self) -> async_graphql::Result<Option<u32>> {
+        Ok(self.high_file)
     }
     pub async fn tracker_file_extension(&self) -> async_graphql::Result<Option<&str>> {
-        Ok(self.tracker_file_extension.as_deref())
+        Ok(self.db_config.tracker_file_extension.as_deref())
     }
 }
 
@@ -299,19 +308,20 @@ impl Query {
         &self,
         ctx: &Context<'_>,
         beamline: String,
-    ) -> async_graphql::Result<BeamlineConfiguration> {
+    ) -> async_graphql::Result<CurrentConfiguration> {
         check_auth(ctx, |policy, token| policy.check_admin(token, &beamline)).await?;
         let db = ctx.data::<SqliteScanPathService>()?;
         let nt = ctx.data::<NumTracker>()?;
         trace!("Getting config for {beamline:?}");
         let conf = db.current_configuration(&beamline).await?;
-        let dir = nt.for_beamline(&beamline, conf.extension()).await?;
-        if let Some(high) = dir.prev().await?.filter(|n| n > &conf.scan_number()) {
-            // high file number in directory is higher than the configured value in the DB
-            Ok(conf.with_scan_number(high))
-        } else {
-            Ok(conf)
-        }
+        let dir = nt
+            .for_beamline(&beamline, conf.tracker_file_extension.as_deref())
+            .await?;
+        let high_file = dir.prev().await?;
+        Ok(CurrentConfiguration {
+            db_config: conf,
+            high_file,
+        })
     }
 }
 
@@ -363,15 +373,24 @@ impl Mutation {
         ctx: &Context<'ctx>,
         beamline: String,
         config: ConfigurationUpdates,
-    ) -> async_graphql::Result<BeamlineConfiguration> {
+    ) -> async_graphql::Result<CurrentConfiguration> {
         check_auth(ctx, |pc, token| pc.check_admin(token, &beamline)).await?;
         let db = ctx.data::<SqliteScanPathService>()?;
         trace!("Configuring: {beamline}: {config:?}");
-        let upd = config.into_update(beamline);
-        match upd.update_beamline(db).await? {
-            Some(bc) => Ok(bc),
-            None => Ok(upd.insert_new(db).await?),
-        }
+        let upd = config.into_update(&beamline);
+        let db_config = match upd.update_beamline(db).await? {
+            Some(bc) => bc,
+            None => upd.insert_new(db).await?,
+        };
+        let dir = ctx
+            .data::<NumTracker>()?
+            .for_beamline(&beamline, db_config.tracker_file_extension.as_deref())
+            .await?;
+        let high_file = dir.prev().await?;
+        Ok(CurrentConfiguration {
+            db_config,
+            high_file,
+        })
     }
 }
 
@@ -403,9 +422,9 @@ struct ConfigurationUpdates {
 }
 
 impl ConfigurationUpdates {
-    fn into_update(self, name: String) -> BeamlineConfigurationUpdate {
+    fn into_update<S: Into<String>>(self, name: S) -> BeamlineConfigurationUpdate {
         BeamlineConfigurationUpdate {
-            name,
+            name: name.into(),
             scan_number: self.scan_number,
             visit: self.visit.map(|t| t.0),
             scan: self.scan.map(|t| t.0),
@@ -631,7 +650,7 @@ mod tests {
             Some(122),
             None,
         );
-        cfg.into_update("i22".into()).insert_new(&db).await.unwrap();
+        cfg.into_update("i22").insert_new(&db).await.unwrap();
         let cfg = updates(
             Some("/tmp/{instrument}/data/{visit}/"),
             Some("{subdirectory}/{instrument}-{scan_number}"),
@@ -639,7 +658,7 @@ mod tests {
             Some(621),
             Some("b21_ext"),
         );
-        cfg.into_update("b21".into()).insert_new(&db).await.unwrap();
+        cfg.into_update("b21").insert_new(&db).await.unwrap();
         db
     }
 
@@ -752,7 +771,7 @@ mod tests {
     async fn configuration(#[future(awt)] env: TestEnv) {
         let query = r#"{
         configuration(beamline: "i22") {
-            visitTemplate scanTemplate detectorTemplate latestScanNumber trackerFileExtension
+            visitTemplate scanTemplate detectorTemplate dbScanNumber trackerFileExtension
         }}"#;
         let result = env.schema.execute(query).await;
         let exp = value!({
@@ -760,7 +779,7 @@ mod tests {
             "visitTemplate": "/tmp/{instrument}/data/{visit}",
             "scanTemplate": "{subdirectory}/{instrument}-{scan_number}",
             "detectorTemplate": "{subdirectory}/{instrument}-{scan_number}-{detector}",
-            "latestScanNumber": 122,
+            "dbScanNumber": 122,
             "trackerFileExtension": Value::Null
         }});
         assert!(result.errors.is_empty());
@@ -791,13 +810,15 @@ mod tests {
             .unwrap();
         let query = r#"{
             configuration(beamline: "i22") {
-                latestScanNumber
+                dbScanNumber
+                fileScanNumber
             }
         }"#;
         let result = env.schema.execute(query).await;
         let exp = value!({
             "configuration": {
-                "latestScanNumber": 5678
+                "dbScanNumber": 122,
+                "fileScanNumber": 5678
             }
         });
         assert!(result.errors.is_empty());
@@ -817,7 +838,7 @@ mod tests {
     async fn empty_configure_for_existing(#[future(awt)] env: TestEnv) {
         let query = r#"mutation {
             configure(beamline: "i22", config: {}) {
-                visitTemplate scanTemplate detectorTemplate latestScanNumber
+                visitTemplate scanTemplate detectorTemplate dbScanNumber
             }
         }"#;
         let result = env.schema.execute(query).await;
@@ -826,7 +847,7 @@ mod tests {
                 "visitTemplate": "/tmp/{instrument}/data/{visit}",
                 "scanTemplate": "{subdirectory}/{instrument}-{scan_number}",
                 "detectorTemplate": "{subdirectory}/{instrument}-{scan_number}-{detector}",
-                "latestScanNumber": 122
+                "dbScanNumber": 122
             }
         });
         println!("{result:#?}");
@@ -875,7 +896,7 @@ mod tests {
                         scan: "{instrument}-{scan_number}"
                         detector: "{scan_number}-{detector}"
                     }) {
-                        scanTemplate visitTemplate detectorTemplate latestScanNumber
+                        scanTemplate visitTemplate detectorTemplate dbScanNumber
                     }
                 }"#,
             )
@@ -884,7 +905,7 @@ mod tests {
                 "visitTemplate": "/tmp/{instrument}/{year}/{visit}",
                 "scanTemplate": "{instrument}-{scan_number}",
                 "detectorTemplate": "{scan_number}-{detector}",
-                "latestScanNumber": 0
+                "dbScanNumber": 0
             } });
         assert!(result.errors.is_empty());
         assert_eq!(result.data, exp);

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -266,7 +266,7 @@ impl CurrentConfiguration {
         Ok(self.high_file)
     }
     pub async fn tracker_file_extension(&self) -> async_graphql::Result<Option<&str>> {
-        Ok(self.db_config.tracker_file_extension.as_deref())
+        Ok(self.db_config.tracker_file_extension())
     }
 }
 
@@ -315,7 +315,7 @@ impl Query {
         trace!("Getting config for {beamline:?}");
         let conf = db.current_configuration(&beamline).await?;
         let dir = nt
-            .for_beamline(&beamline, conf.tracker_file_extension.as_deref())
+            .for_beamline(&beamline, conf.tracker_file_extension())
             .await?;
         let high_file = dir.prev().await?;
         Ok(CurrentConfiguration {
@@ -347,7 +347,7 @@ impl Mutation {
         // isn't much we can do from here.
         let current = db.current_configuration(&beamline).await?;
         let dir = nt
-            .for_beamline(&beamline, current.tracker_file_extension.as_deref())
+            .for_beamline(&beamline, current.tracker_file_extension())
             .await?;
 
         let next_scan = db
@@ -384,7 +384,7 @@ impl Mutation {
         };
         let dir = ctx
             .data::<NumTracker>()?
-            .for_beamline(&beamline, db_config.tracker_file_extension.as_deref())
+            .for_beamline(&beamline, db_config.tracker_file_extension())
             .await?;
         let high_file = dir.prev().await?;
         Ok(CurrentConfiguration {

--- a/static/service_schema
+++ b/static/service_schema
@@ -1,17 +1,18 @@
-type BeamlineConfiguration {
-	visitTemplate: String!
-	scanTemplate: String!
-	detectorTemplate: String!
-	latestScanNumber: Int!
-	trackerFileExtension: String
-}
-
 
 input ConfigurationUpdates {
 	visit: VisitTemplate
 	scan: ScanTemplate
 	detector: DetectorTemplate
 	scanNumber: Int
+	trackerFileExtension: String
+}
+
+type CurrentConfiguration {
+	visitTemplate: String!
+	scanTemplate: String!
+	detectorTemplate: String!
+	dbScanNumber: Int!
+	fileScanNumber: Int
 	trackerFileExtension: String
 }
 
@@ -40,12 +41,12 @@ type Mutation {
 	Access scan file locations for the next scan
 	"""
 	scan(beamline: String!, visit: String!, sub: Subdirectory): ScanPaths!
-	configure(beamline: String!, config: ConfigurationUpdates!): BeamlineConfiguration!
+	configure(beamline: String!, config: ConfigurationUpdates!): CurrentConfiguration!
 }
 
 type Query {
 	paths(beamline: String!, visit: String!): VisitPath!
-	configuration(beamline: String!): BeamlineConfiguration!
+	configuration(beamline: String!): CurrentConfiguration!
 }
 
 type ScanPaths {


### PR DESCRIPTION
- **Add failing test to demonstrate required behaviour**
- **Check directory for highest number when returning configuration**

Fix for #50 

I'm not convinced this doesn't just move the confusion elsewhere. It doesn't give the same `get configuration latestScanNumber -> 0` followed by `get next scan number -> 42` behaviour but does mean `get configuration` doesn't return the same configuration you've just set via `set configuration`.

Maybe `get configuration` would be better off returning a different type with db_number and dir_number as different fields?