### PR TITLE
Standardise name of tracker_file_extension

### DIFF
--- a/.sqlx/query-1ad61bdc8babbb4403c535318ccf657b3ea98a04126539ccf08f8251d87ed32b.json
+++ b/.sqlx/query-1ad61bdc8babbb4403c535318ccf657b3ea98a04126539ccf08f8251d87ed32b.json
@@ -1,6 +1,6 @@
 {
   "db_name": "SQLite",
-  "query": "INSERT INTO beamline\n                (name, scan_number, visit, scan, detector, fallback_extension)\n            VALUES\n                (?,?,?,?,?,?)\n            RETURNING *",
+  "query": "INSERT INTO beamline\n                (name, scan_number, visit, scan, detector, tracker_file_extension)\n            VALUES\n                (?,?,?,?,?,?)\n            RETURNING *",
   "describe": {
     "columns": [
       {
@@ -34,7 +34,7 @@
         "type_info": "Text"
       },
       {
-        "name": "fallback_extension",
+        "name": "tracker_file_extension",
         "ordinal": 6,
         "type_info": "Text"
       }
@@ -52,5 +52,5 @@
       true
     ]
   },
-  "hash": "77054c7c20195a2a7766eb83bf39add56ec84bb502ce39d26cd9394703bdd71a"
+  "hash": "1ad61bdc8babbb4403c535318ccf657b3ea98a04126539ccf08f8251d87ed32b"
 }

--- a/.sqlx/query-7b769dea685f49e8ff6d24a69e69e7037c1dc197db8bd273ec53e63a85e85351.json
+++ b/.sqlx/query-7b769dea685f49e8ff6d24a69e69e7037c1dc197db8bd273ec53e63a85e85351.json
@@ -34,7 +34,7 @@
         "type_info": "Text"
       },
       {
-        "name": "fallback_extension",
+        "name": "tracker_file_extension",
         "ordinal": 6,
         "type_info": "Text"
       }

--- a/.sqlx/query-e45d346b58374c69e4f3bb59935719177993012eb03ce8f2d9bcca00290690be.json
+++ b/.sqlx/query-e45d346b58374c69e4f3bb59935719177993012eb03ce8f2d9bcca00290690be.json
@@ -34,7 +34,7 @@
         "type_info": "Text"
       },
       {
-        "name": "fallback_extension",
+        "name": "tracker_file_extension",
         "ordinal": 6,
         "type_info": "Text"
       }

--- a/migrations/0002_extension_name.down.sql
+++ b/migrations/0002_extension_name.down.sql
@@ -1,0 +1,3 @@
+-- Revert back to fallback_extension name
+ALTER TABLE beamline
+RENAME COLUMN tracker_file_extension TO fallback_extension;

--- a/migrations/0002_extension_name.up.sql
+++ b/migrations/0002_extension_name.up.sql
@@ -1,0 +1,3 @@
+-- Rename column to match renamed struct field
+ALTER TABLE beamline
+RENAME COLUMN fallback_extension TO tracker_file_extension;

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -325,14 +325,16 @@ impl Mutation {
         // while the DB is being queried or between the two queries but there
         // isn't much we can do from here.
         let current = db.current_configuration(&beamline).await?;
-        let dir = nt.for_beamline(&beamline, current.extension()).await?;
+        let dir = nt
+            .for_beamline(&beamline, current.tracker_file_extension())
+            .await?;
 
         let next_scan = db
             .next_scan_configuration(&beamline, dir.prev().await?)
             .await?;
 
         if let Err(e) = dir.set(next_scan.scan_number()).await {
-            warn!("Failed to increment fallback tracker directory: {e}");
+            warn!("Failed to increment tracker file: {e}");
         }
 
         Ok(ScanPaths {
@@ -386,7 +388,7 @@ struct ConfigurationUpdates {
     scan: Option<InputTemplate<ScanTemplate>>,
     detector: Option<InputTemplate<DetectorTemplate>>,
     scan_number: Option<u32>,
-    extension: Option<String>,
+    tracker_file_extension: Option<String>,
 }
 
 impl ConfigurationUpdates {
@@ -397,7 +399,7 @@ impl ConfigurationUpdates {
             visit: self.visit.map(|t| t.0),
             scan: self.scan.map(|t| t.0),
             detector: self.detector.map(|t| t.0),
-            extension: self.extension,
+            tracker_file_extension: self.tracker_file_extension,
         }
     }
 }
@@ -597,7 +599,7 @@ mod tests {
             scan: scan.map(|s| InputTemplate::parse(Some(Value::String(s.into()))).unwrap()),
             detector: det.map(|d| InputTemplate::parse(Some(Value::String(d.into()))).unwrap()),
             scan_number: num,
-            extension: ext.map(|e| e.into()),
+            tracker_file_extension: ext.map(|e| e.into()),
         }
     }
 

--- a/static/service_schema
+++ b/static/service_schema
@@ -11,7 +11,7 @@ input ConfigurationUpdates {
 	scan: ScanTemplate
 	detector: DetectorTemplate
 	scanNumber: Int
-	extension: String
+	trackerFileExtension: String
 }
 
 scalar Detector


### PR DESCRIPTION
Instead of using fallback_extension and extension in different places. This is the file used by the GDA numtracker and should not be confused with any extension used for the scan files generated by the service.