### PR TITLE
Split async-graphql into its own dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,10 @@ updates:
         patterns:
           - opentelemetry*
           - tracing*
+      async_graphql:
+        # Split async graphql into its own group as it doesn't follow semver
+        patterns:
+          - async-graphql*
       patch:
         update-types:
           - patch


### PR DESCRIPTION
The project doesn't follow semver and bundling updates into other patch
updates blocks update PRs from being merged.

Three breaking changes in the last five patch versions:
* [7.0.9](https://github.com/async-graphql/async-graphql/issues/1634)
* [7.0.11](https://github.com/async-graphql/async-graphql/issues/1645)
* [7.0.14](https://github.com/async-graphql/async-graphql/issues/1660)
