### PR TITLE
Add catalog-info file for Dev Portal

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,31 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: numtracker
+  title: Athena Numtracker
+  description: Service to provide automatic data-file numbering and path management according to existing Diamond conventions.
+  annotations:
+    github.com/project-slug: DiamondLightSource/numtracker
+    diamond.ac.uk/viewdocs-url: https://github.com/DiamondLightSource/numtracker/blob/main/README.md
+spec:
+  type: service
+  lifecycle: production
+  owner: group:data-acquisition
+  system: athena
+  providesApis:
+    - numtracker
+---
+apiVersion: backstage.io/v1alpha1
+kind: API
+metadata:
+  name: numtracker
+  title: Athena Numtracker
+  description: GraphQL API for retrieving and generating Visit data-file numbers and paths
+  annotations:
+    github.com/project-slug: DiamondLightSource/numtracker
+spec:
+  type: openapi
+  lifecycle: production
+  owner: user:qan22331
+  definition:
+    $text: ./static/service_schema

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -7,6 +7,9 @@ metadata:
   annotations:
     github.com/project-slug: DiamondLightSource/numtracker
     diamond.ac.uk/viewdocs-url: https://github.com/DiamondLightSource/numtracker/blob/main/README.md
+  tags:
+    - rust
+    - graphql
 spec:
   type: service
   lifecycle: production
@@ -26,6 +29,6 @@ metadata:
 spec:
   type: openapi
   lifecycle: production
-  owner: user:qan22331
+  owner: group:data-acquisition
   definition:
     $text: ./static/service_schema


### PR DESCRIPTION
Add catalog-info.yaml file to the repo to allow it to be registered on the Dev Portal. For the moment point the docs tab at the Readme file and the API definition at the schema file in the satic folder.