### PR TITLE
Bump MSRV to 1.83

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ name = "numtracker"
 version = "0.0.0"
 edition = "2021"
 license = "Apache-2.0"
-rust-version = "1.82"
+rust-version = "1.83"
 
 [lints.clippy]
 unwrap_used = "deny"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.82.0-slim AS build
+FROM rust:1.84.1-slim AS build
 
 RUN rustup target add x86_64-unknown-linux-musl && \
     apt-get update && \


### PR DESCRIPTION
Changes to built now require 1.83 to allow const references to statics
