### PR TITLE
Check for changed files during the CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,3 +60,6 @@ jobs:
       run: cargo build --all-targets
     - name: Run tests
       run: cargo test --all-targets --verbose
+    # Ensure that no files (most likely the Cargo.lock file) have changed
+    - name: Unstaged Changes
+      run: git diff --exit-code


### PR DESCRIPTION
If dependencies are updated by a change, the lock file should be updated
to match. If it is out of sync it will be updated during the build and
be left as an unstaged change. If there are any unstaged changes at the
end of the build, the CI should now fail.
