### PR TITLE
Add _config.yml to fix README pages formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ JSON object as `{"query": "<query-string>"}` taking care to escape quotes as
 required. Using `curl` and a basic visit directory query (see below), this
 looks something like
 ```bash
-echo '{                                                                                        17:15:56
+echo '{
      "query": "{
          paths(beamline: \"i22\", visit: \"cm37278-5\") {
              directory

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ cargo run schema
 ## Queries
 
 <details>
-<summary>Testing queries from terminal</summary>
+<summary markdown="span">Testing queries from terminal</summary>
 
 While the graphiql front-end can be useful for exploring the API schema, running
 from the terminal is sometimes quicker/easier. This only requires `curl`

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,4 @@
+# Configuration for converting the README to a legible github pages page
+markdown: kramdown
+kramdown:
+  parse_block_html: true


### PR DESCRIPTION
Based on comments on jekyll issue [here](https://github.com/jekyll/jekyll/issues/9297)