### PR TITLE
Add time based placeholders for scan/visit templates

### DIFF
--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -37,7 +37,7 @@ use axum::{Extension, Json, Router};
 use axum_extra::headers::authorization::Bearer;
 use axum_extra::headers::Authorization;
 use axum_extra::TypedHeader;
-use chrono::{Datelike, Local};
+use chrono::{DateTime, Datelike, Local};
 use tokio::net::TcpListener;
 use tracing::{info, instrument, trace, warn};
 
@@ -147,6 +147,7 @@ struct VisitPath {
 struct ScanPaths {
     visit: VisitPath,
     subdirectory: Subdirectory,
+    timestamp: DateTime<Local>,
 }
 
 /// GraphQL type to provide current configuration for a beamline
@@ -301,6 +302,8 @@ impl FieldSource<ScanField> for ScanPaths {
             ScanField::Subdirectory => self.subdirectory.to_string().into(),
             ScanField::ScanNumber => self.visit.info.scan_number().to_string().into(),
             ScanField::Beamline(bl) => self.visit.resolve(bl),
+            ScanField::YearMonthDay => self.timestamp.format("%Y%m%d").to_string().into(),
+            ScanField::HourMinuteSecond => self.timestamp.format("%H%M%S").to_string().into(),
         }
     }
 }
@@ -427,6 +430,7 @@ impl Mutation {
                 visit,
                 info: next_scan,
             },
+            timestamp: Local::now(),
             subdirectory: sub.unwrap_or_default(),
         })
     }

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -31,6 +31,8 @@ pub enum BeamlineField {
 pub enum ScanField {
     Subdirectory,
     ScanNumber,
+    YearMonthDay,
+    HourMinuteSecond,
     Beamline(BeamlineField),
 }
 
@@ -57,6 +59,8 @@ impl Display for ScanField {
             ScanField::Subdirectory => f.write_str("subdirectory"),
             ScanField::ScanNumber => f.write_str("scan_number"),
             ScanField::Beamline(bl) => write!(f, "{bl}"),
+            ScanField::YearMonthDay => f.write_str("ts_ymd"),
+            ScanField::HourMinuteSecond => f.write_str("ts_hms"),
         }
     }
 }
@@ -100,6 +104,8 @@ impl TryFrom<String> for ScanField {
         match value.as_str() {
             "scan_number" => Ok(ScanField::ScanNumber),
             "subdirectory" => Ok(ScanField::Subdirectory),
+            "ts_hms" => Ok(ScanField::HourMinuteSecond),
+            "ts_ymd" => Ok(ScanField::YearMonthDay),
             _ => Ok(ScanField::Beamline(BeamlineField::try_from(value)?)),
         }
     }


### PR DESCRIPTION
{ts_hms} for HourMinuteSecond, eg 142117
{ts_ymd} for YearMonthDay, eg 20250221

There is scope for the year in the visit to not match the year in the timestamp
if run exactly at midnight on NYD. If this is deemed likely enough to be an
issue, we can duplicate the timestamp into the VisitPaths as well as the
ScanPaths.
