### PR TITLE
Use `derive_more` for common trait implementations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -880,6 +880,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.95",
+ "unicode-xid",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2022,6 +2043,7 @@ dependencies = [
  "built",
  "chrono",
  "clap",
+ "derive_more",
  "futures",
  "httpmock",
  "opentelemetry",
@@ -3623,6 +3645,12 @@ name = "unicode-properties"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ axum = "0.8.1"
 axum-extra = { version = "0.10.0", features = ["typed-header"] }
 chrono = "0.4.39"
 clap = { version = "4.5.30", features = ["cargo", "derive", "env", "string"] }
+derive_more = { version = "2.0.1", features = ["error", "display", "from", "deref"] }
 futures = "0.3.31"
 opentelemetry = "0.28.0"
 opentelemetry-otlp = { version = "0.28.0", features = ["grpc-tonic"] }

--- a/src/graphql/auth.rs
+++ b/src/graphql/auth.rs
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::fmt::Display;
 use std::str::FromStr;
 
 use axum_extra::headers::authorization::Bearer;
 use axum_extra::headers::Authorization;
+use derive_more::{Display, Error, From};
 use serde::{Deserialize, Serialize};
 use tracing::info;
 
@@ -162,36 +162,14 @@ impl PolicyCheck {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Display, Error, From)]
 pub enum AuthError {
+    #[display("Invalid authorization configuration")]
     ServerError(reqwest::Error),
+    #[display("Authentication failed")]
     Failed,
+    #[display("No authentication token was provided")]
     Missing,
-}
-
-impl Display for AuthError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            AuthError::ServerError(_) => write!(f, "Invalid authorization configuration"),
-            AuthError::Failed => write!(f, "Authentication failed"),
-            AuthError::Missing => f.write_str("No authentication token was provided"),
-        }
-    }
-}
-
-impl std::error::Error for AuthError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            AuthError::ServerError(e) => Some(e),
-            _ => None,
-        }
-    }
-}
-
-impl From<reqwest::Error> for AuthError {
-    fn from(value: reqwest::Error) -> Self {
-        Self::ServerError(value)
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Replaces mostly trivial implementations of From<E> for errors, Display,
Error and Deref.
