### PR TITLE
Remove opentelemetry-stdout dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2049,7 +2049,6 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
- "opentelemetry-stdout",
  "opentelemetry_sdk",
  "reqwest",
  "rstest",
@@ -2145,21 +2144,6 @@ name = "opentelemetry-semantic-conventions"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fb3a2f78c2d55362cd6c313b8abedfbc0142ab3c2676822068fd2ab7d51f9b7"
-
-[[package]]
-name = "opentelemetry-stdout"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eb0e5a5132e4b80bf037a78e3e12c8402535199f5de490d0c38f7eac71bc831"
-dependencies = [
- "async-trait",
- "chrono",
- "futures-util",
- "opentelemetry",
- "opentelemetry_sdk",
- "serde",
- "thiserror 2.0.9",
-]
 
 [[package]]
 name = "opentelemetry_sdk"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ futures = "0.3.31"
 opentelemetry = "0.28.0"
 opentelemetry-otlp = { version = "0.28.0", features = ["grpc-tonic"] }
 opentelemetry-semantic-conventions = "0.28.0"
-opentelemetry-stdout = "0.28.0"
 opentelemetry_sdk = { version = "0.28.0", features = ["rt-tokio"] }
 reqwest = { version = "0.12.7", features = ["json", "rustls-tls"], default-features = false }
 serde = { version = "1.0.218", features = ["derive"] }


### PR DESCRIPTION
This is not used as the tracing_subscriber crate is used for logging to
the console instead.
