### PR TITLE
Use standard names for graphql fields

### DIFF
--- a/.sqlx/query-30e7b9868a569ff84bf63ad3f750cd3f81e49b4836604e2d040c09aba1b590b0.json
+++ b/.sqlx/query-30e7b9868a569ff84bf63ad3f750cd3f81e49b4836604e2d040c09aba1b590b0.json
@@ -19,7 +19,7 @@
         "type_info": "Integer"
       },
       {
-        "name": "visit",
+        "name": "directory",
         "ordinal": 3,
         "type_info": "Text"
       },

--- a/.sqlx/query-30e7b9868a569ff84bf63ad3f750cd3f81e49b4836604e2d040c09aba1b590b0.json
+++ b/.sqlx/query-30e7b9868a569ff84bf63ad3f750cd3f81e49b4836604e2d040c09aba1b590b0.json
@@ -1,6 +1,6 @@
 {
   "db_name": "SQLite",
-  "query": "SELECT * FROM beamline WHERE name = ?",
+  "query": "SELECT * FROM instrument",
   "describe": {
     "columns": [
       {
@@ -40,7 +40,7 @@
       }
     ],
     "parameters": {
-      "Right": 1
+      "Right": 0
     },
     "nullable": [
       false,
@@ -52,5 +52,5 @@
       true
     ]
   },
-  "hash": "e45d346b58374c69e4f3bb59935719177993012eb03ce8f2d9bcca00290690be"
+  "hash": "30e7b9868a569ff84bf63ad3f750cd3f81e49b4836604e2d040c09aba1b590b0"
 }

--- a/.sqlx/query-6d1e14903687dc07c77d9dbc0e2e2bf1cf90adca88506b4c484f4f6234463200.json
+++ b/.sqlx/query-6d1e14903687dc07c77d9dbc0e2e2bf1cf90adca88506b4c484f4f6234463200.json
@@ -19,7 +19,7 @@
         "type_info": "Integer"
       },
       {
-        "name": "visit",
+        "name": "directory",
         "ordinal": 3,
         "type_info": "Text"
       },

--- a/.sqlx/query-6d1e14903687dc07c77d9dbc0e2e2bf1cf90adca88506b4c484f4f6234463200.json
+++ b/.sqlx/query-6d1e14903687dc07c77d9dbc0e2e2bf1cf90adca88506b4c484f4f6234463200.json
@@ -1,6 +1,6 @@
 {
   "db_name": "SQLite",
-  "query": "SELECT * FROM beamline",
+  "query": "UPDATE instrument SET scan_number = max(scan_number, ?) + 1 WHERE name = ? RETURNING *",
   "describe": {
     "columns": [
       {
@@ -40,7 +40,7 @@
       }
     ],
     "parameters": {
-      "Right": 0
+      "Right": 2
     },
     "nullable": [
       false,
@@ -52,5 +52,5 @@
       true
     ]
   },
-  "hash": "02d6faf0ffd8fb96031f7a8e824de4e4552ea72176c5e885cea3e517316e7774"
+  "hash": "6d1e14903687dc07c77d9dbc0e2e2bf1cf90adca88506b4c484f4f6234463200"
 }

--- a/.sqlx/query-6deeea832def01a5573571c1c45662029080dd82a21ab6602c994222285d216e.json
+++ b/.sqlx/query-6deeea832def01a5573571c1c45662029080dd82a21ab6602c994222285d216e.json
@@ -1,6 +1,6 @@
 {
   "db_name": "SQLite",
-  "query": "UPDATE beamline SET scan_number = max(scan_number, ?) + 1 WHERE name = ? RETURNING *",
+  "query": "INSERT INTO instrument\n                (name, scan_number, visit, scan, detector, tracker_file_extension)\n            VALUES\n                (?,?,?,?,?,?)\n            RETURNING *",
   "describe": {
     "columns": [
       {
@@ -40,7 +40,7 @@
       }
     ],
     "parameters": {
-      "Right": 2
+      "Right": 6
     },
     "nullable": [
       false,
@@ -52,5 +52,5 @@
       true
     ]
   },
-  "hash": "7b769dea685f49e8ff6d24a69e69e7037c1dc197db8bd273ec53e63a85e85351"
+  "hash": "6deeea832def01a5573571c1c45662029080dd82a21ab6602c994222285d216e"
 }

--- a/.sqlx/query-732d78dd385205d3a4f4b2f71dc98cf755078ddff46bdc3b6c0074d4cc885a1f.json
+++ b/.sqlx/query-732d78dd385205d3a4f4b2f71dc98cf755078ddff46bdc3b6c0074d4cc885a1f.json
@@ -1,6 +1,6 @@
 {
   "db_name": "SQLite",
-  "query": "INSERT INTO instrument\n                (name, scan_number, visit, scan, detector, tracker_file_extension)\n            VALUES\n                (?,?,?,?,?,?)\n            RETURNING *",
+  "query": "INSERT INTO instrument\n                (name, scan_number, directory, scan, detector, tracker_file_extension)\n            VALUES\n                (?,?,?,?,?,?)\n            RETURNING *",
   "describe": {
     "columns": [
       {
@@ -19,7 +19,7 @@
         "type_info": "Integer"
       },
       {
-        "name": "visit",
+        "name": "directory",
         "ordinal": 3,
         "type_info": "Text"
       },
@@ -52,5 +52,5 @@
       true
     ]
   },
-  "hash": "6deeea832def01a5573571c1c45662029080dd82a21ab6602c994222285d216e"
+  "hash": "732d78dd385205d3a4f4b2f71dc98cf755078ddff46bdc3b6c0074d4cc885a1f"
 }

--- a/.sqlx/query-99bf4cc482254ce2a89496c99e65d87a0a44be3838754fe180d9e724722af52f.json
+++ b/.sqlx/query-99bf4cc482254ce2a89496c99e65d87a0a44be3838754fe180d9e724722af52f.json
@@ -19,7 +19,7 @@
         "type_info": "Integer"
       },
       {
-        "name": "visit",
+        "name": "directory",
         "ordinal": 3,
         "type_info": "Text"
       },

--- a/.sqlx/query-99bf4cc482254ce2a89496c99e65d87a0a44be3838754fe180d9e724722af52f.json
+++ b/.sqlx/query-99bf4cc482254ce2a89496c99e65d87a0a44be3838754fe180d9e724722af52f.json
@@ -1,6 +1,6 @@
 {
   "db_name": "SQLite",
-  "query": "INSERT INTO beamline\n                (name, scan_number, visit, scan, detector, tracker_file_extension)\n            VALUES\n                (?,?,?,?,?,?)\n            RETURNING *",
+  "query": "SELECT * FROM instrument WHERE name = ?",
   "describe": {
     "columns": [
       {
@@ -40,7 +40,7 @@
       }
     ],
     "parameters": {
-      "Right": 6
+      "Right": 1
     },
     "nullable": [
       false,
@@ -52,5 +52,5 @@
       true
     ]
   },
-  "hash": "1ad61bdc8babbb4403c535318ccf657b3ea98a04126539ccf08f8251d87ed32b"
+  "hash": "99bf4cc482254ce2a89496c99e65d87a0a44be3838754fe180d9e724722af52f"
 }

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ version of the compiler (1.81+). This is available from [rustup.rs][_rustup].
 
 At this point the service is running and can be queried via the graphQL
 endpoints (see [the graphiql][_graphiql] front-end available at
-`localhost:8000/graphiql` by default) but there are no beamlines configured.
+`localhost:8000/graphiql` by default) but there are no instruments configured.
 
 Additional logging output is available via `-v` verbose flags.
 
@@ -73,7 +73,7 @@ looks something like
 ```bash
 echo '{
      "query": "{
-         paths(beamline: \"i22\", visit: \"cm37278-5\") {
+         paths(instrument: \"i22\", visit: \"cm37278-5\") {
              directory
          }
      }"
@@ -84,16 +84,17 @@ echo '{
 
 ### Queries (read-only)
 There are three read only queries, one to get the visit directory for a given
-visit and beamline, one to get the current configuration for a given
-beamline and one to get the current configuration(s) for one or more beamline.
+visit and instrument, one to get the current configuration for a given
+instrument and one to get the current configuration(s) for one or more
+instruments.
 
 #### paths
-Get the visit directory for a beamline and visit
+Get the visit directory for an instrument and visit
 
 ##### Query
 ```graphql
 {
-  paths(beamline: "i22", visit: "cm12345-6") {
+  paths(instrument: "i22", visit: "cm12345-6") {
     directory
     visit
   }
@@ -110,12 +111,12 @@ Get the visit directory for a beamline and visit
 ```
 
 #### configuration
-Get the current configuration values for the given beamline
+Get the current configuration values for the given instrument
 
 ##### Query
 ```graphql
 {
-  configuration(beamline: "i22") {
+  configuration(instrument: "i22") {
     visitTemplate
     scanTemplate
     detectorTemplate
@@ -141,14 +142,15 @@ Get the current configuration values for the given beamline
 ```
 
 #### configurations
-Get the current configuration values for one or more beamlines specified as a list.
-Providing no beamlines returns all current configurations.
+Get the current configuration values for one or more instruments specified as a
+list. Providing no list returns all current configurations whereas providing an
+empty list will return no configurations.
 
 ##### Query
 ```graphql
 {
-    configurations(beamlineFilters: ["i22", "i11"]) {
-    beamline
+    configurations(instrumentFilters: ["i22", "i11"]) {
+    instrument
     visitTemplate
     scanTemplate
     detectorTemplate
@@ -164,7 +166,7 @@ Providing no beamlines returns all current configurations.
 {
   "configurations": [
       {
-        "beamline": "i11",
+        "instrument": "i11",
         "visitTemplate": "/tmp/{instrument}/data/{year}/{visit}",
         "scanTemplate": "{subdirectory}/{instrument}-{scan_number}",
         "detectorTemplate": "{subdirectory}/{instrument}-{scan_number}-{detector}",
@@ -173,7 +175,7 @@ Providing no beamlines returns all current configurations.
         "trackerFileExtension": null
       },
       {
-        "beamline": "i22",
+        "instrument": "i22",
         "visitTemplate": "/tmp/{instrument}/data/{year}/{visit}",
         "scanTemplate": "{subdirectory}/{instrument}-{scan_number}",
         "detectorTemplate": "{subdirectory}/{instrument}-{scan_number}-{detector}",
@@ -189,7 +191,7 @@ Providing no beamlines returns all current configurations.
 ```graphql
 {
     configurations {
-    beamline
+    instrument
     visitTemplate
     scanTemplate
     detectorTemplate
@@ -205,7 +207,7 @@ Providing no beamlines returns all current configurations.
 {
   "configurations": [
       {
-        "beamline": "i11",
+        "instrument": "i11",
         "visitTemplate": "/tmp/{instrument}/data/{year}/{visit}",
         "scanTemplate": "{subdirectory}/{instrument}-{scan_number}",
         "detectorTemplate": "{subdirectory}/{instrument}-{scan_number}-{detector}",
@@ -226,7 +228,7 @@ Providing no beamlines returns all current configurations.
 
 ```graphql
 mutation {
-  scan(beamline: "i22", visit: "cm12345-2", subdirectory: "sub/tree") {
+  scan(instrument: "i22", visit: "cm12345-2", subdirectory: "sub/tree") {
       scanFile
       scanNumber
       detectors(names: ["det1", "det2"] ) {
@@ -261,7 +263,7 @@ mutation {
 ##### Query
 ```graphql
 mutation {
-  configure(beamline: "i11", config: {
+  configure(instrument: "i11", config: {
       visit:"/tmp/{instrument}/data/{year}/{visit}"
       scan:"{subdirectory}/{instrument}-{scan_number}"
       detector:"{subdirectory}/{instrument}-{scan_number}-{detector}"

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Get the current configuration values for the given instrument
 ```graphql
 {
   configuration(instrument: "i22") {
-    visitTemplate
+    directoryTemplate
     scanTemplate
     detectorTemplate
     dbScanNumber
@@ -131,7 +131,7 @@ Get the current configuration values for the given instrument
 ```json
 {
   "configuration": {
-    "visitTemplate": "/data/{instrument}/data/{year}/{visit}",
+    "directoryTemplate": "/data/{instrument}/data/{year}/{visit}",
     "scanTemplate": "{subdirectory}/{instrument}-{scan_number}",
     "detectorTemplate": "{subdirectory}/{instrument}-{scan_number}-{detector}",
     "dbScanNumber": 0,
@@ -151,7 +151,7 @@ empty list will return no configurations.
 {
     configurations(instrumentFilters: ["i22", "i11"]) {
     instrument
-    visitTemplate
+    directoryTemplate
     scanTemplate
     detectorTemplate
     dbScanNumber
@@ -167,7 +167,7 @@ empty list will return no configurations.
   "configurations": [
       {
         "instrument": "i11",
-        "visitTemplate": "/tmp/{instrument}/data/{year}/{visit}",
+        "directoryTemplate": "/tmp/{instrument}/data/{year}/{visit}",
         "scanTemplate": "{subdirectory}/{instrument}-{scan_number}",
         "detectorTemplate": "{subdirectory}/{instrument}-{scan_number}-{detector}",
         "dbScanNumber": 0,
@@ -176,7 +176,7 @@ empty list will return no configurations.
       },
       {
         "instrument": "i22",
-        "visitTemplate": "/tmp/{instrument}/data/{year}/{visit}",
+        "directoryTemplate": "/tmp/{instrument}/data/{year}/{visit}",
         "scanTemplate": "{subdirectory}/{instrument}-{scan_number}",
         "detectorTemplate": "{subdirectory}/{instrument}-{scan_number}-{detector}",
         "dbScanNumber": 0,
@@ -192,7 +192,7 @@ empty list will return no configurations.
 {
     configurations {
     instrument
-    visitTemplate
+    directoryTemplate
     scanTemplate
     detectorTemplate
     dbScanNumber
@@ -208,7 +208,7 @@ empty list will return no configurations.
   "configurations": [
       {
         "instrument": "i11",
-        "visitTemplate": "/tmp/{instrument}/data/{year}/{visit}",
+        "directoryTemplate": "/tmp/{instrument}/data/{year}/{visit}",
         "scanTemplate": "{subdirectory}/{instrument}-{scan_number}",
         "detectorTemplate": "{subdirectory}/{instrument}-{scan_number}-{detector}",
         "dbScanNumber": 0,
@@ -264,12 +264,12 @@ mutation {
 ```graphql
 mutation {
   configure(instrument: "i11", config: {
-      visit:"/tmp/{instrument}/data/{year}/{visit}"
+      directory:"/tmp/{instrument}/data/{year}/{visit}"
       scan:"{subdirectory}/{instrument}-{scan_number}"
       detector:"{subdirectory}/{instrument}-{scan_number}-{detector}"
       scanNumber: 12345
     }) {
-      visitTemplate
+      directoryTemplate
       scanTemplate
       detectorTemplate
       latestScanNumber
@@ -281,7 +281,7 @@ mutation {
 ```json
 {
   "configure": {
-    "visitTemplate": "/tmp/{instrument}/data/{year}/{visit}",
+    "directoryTemplate": "/tmp/{instrument}/data/{year}/{visit}",
     "scanTemplate": "{subdirectory}/{instrument}-{scan_number}",
     "detectorTemplate": "{subdirectory}/{instrument}-{scan_number}-{detector}",
     "latestScanNumber": 12345

--- a/README.md
+++ b/README.md
@@ -56,6 +56,15 @@ graphiql interface.
 cargo run schema
 ```
 
+> [!NOTE]
+> Within the schema, 'instrument' can be thought of as equivalent to 'beamline'
+> in most other contexts. It is used to include other facilities such as lab
+> sources and electron-microscopes.
+>
+> In a similar way, 'instrumentSession' is what would usually be considered a
+> 'visit', i.e. a single block of time on an instrument for a proposal
+> designated by a code such as cm12345-6.
+
 ## Queries
 
 <details>
@@ -68,13 +77,13 @@ easier to parse output.
 
 The query to run should be made as a POST request to `/graphql` wrapped in a
 JSON object as `{"query": "<query-string>"}` taking care to escape quotes as
-required. Using `curl` and a basic visit directory query (see below), this
+required. Using `curl` and a basic data directory query (see below), this
 looks something like
 ```bash
 echo '{
      "query": "{
-         paths(instrument: \"i22\", visit: \"cm37278-5\") {
-             directory
+         paths(instrument: \"i22\", instrumentSession: \"cm37278-5\") {
+             path
          }
      }"
  }'| curl -s -X POST 127.0.0.1:8000/graphql -H "Content-Type: application/json" -d @- | jq
@@ -83,20 +92,20 @@ echo '{
 </details>
 
 ### Queries (read-only)
-There are three read only queries, one to get the visit directory for a given
-visit and instrument, one to get the current configuration for a given
+There are three read only queries, one to get the data directory for a given
+instrument session and instrument, one to get the current configuration for a given
 instrument and one to get the current configuration(s) for one or more
 instruments.
 
 #### paths
-Get the visit directory for an instrument and visit
+Get the data directory for an instrument and instrument session
 
 ##### Query
 ```graphql
 {
-  paths(instrument: "i22", visit: "cm12345-6") {
-    directory
-    visit
+  paths(instrument: "i22", instrumentSession: "cm12345-6") {
+    path
+    instrumentSession
   }
 }
 ```
@@ -104,8 +113,8 @@ Get the visit directory for an instrument and visit
 ```json
 {
   "paths": {
-    "directory": "/data/i22/data/2024/cm37278-5",
-    "visit": "cm37278-5"
+    "path": "/data/i22/data/2024/cm37278-5",
+    "instrumentSession": "cm37278-5"
   }
 }
 ```
@@ -149,7 +158,7 @@ empty list will return no configurations.
 ##### Query
 ```graphql
 {
-    configurations(instrumentFilters: ["i22", "i11"]) {
+  configurations(instrumentFilters: ["i22", "i11"]) {
     instrument
     directoryTemplate
     scanTemplate
@@ -190,7 +199,7 @@ empty list will return no configurations.
 ##### Query
 ```graphql
 {
-    configurations {
+  configurations {
     instrument
     directoryTemplate
     scanTemplate
@@ -228,7 +237,7 @@ empty list will return no configurations.
 
 ```graphql
 mutation {
-  scan(instrument: "i22", visit: "cm12345-2", subdirectory: "sub/tree") {
+  scan(instrument: "i22", instrumentSession: "cm12345-2", subdirectory: "sub/tree") {
       scanFile
       scanNumber
       detectors(names: ["det1", "det2"] ) {

--- a/helm/numtracker/Chart.yaml
+++ b/helm/numtracker/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: numtracker
-description: Helm chart to deploy the numtracker service for unifying beamline filenaming
+description: Helm chart to deploy the numtracker service for unifying instrument filenaming
 type: application
 
 # These versions are ignored and are automatically set via the CI process to the version from the tag

--- a/helm/numtracker/values.yaml
+++ b/helm/numtracker/values.yaml
@@ -27,8 +27,8 @@ numtracker:
   auth:
     enabled: false
     # host: OPA instance
-    # admin: rule determining admin access to a beamline
-    # access: rule determining access to a beamline session
+    # admin: rule determining admin access to an instrument
+    # access: rule determining access to an instrument session
 
 
 

--- a/migrations/0003_beamline_instrument.down.sql
+++ b/migrations/0003_beamline_instrument.down.sql
@@ -1,0 +1,2 @@
+-- Revert instrument table back to beamline name
+ALTER TABLE instrument RENAME TO beamline;

--- a/migrations/0003_beamline_instrument.up.sql
+++ b/migrations/0003_beamline_instrument.up.sql
@@ -1,0 +1,2 @@
+-- Rename beamline table to instrument to match standards
+ALTER TABLE beamline RENAME TO instrument;

--- a/migrations/0004_rename_visit_to_directory.down.sql
+++ b/migrations/0004_rename_visit_to_directory.down.sql
@@ -1,0 +1,3 @@
+-- Revert directory column back to visit
+ALTER TABLE instrument
+RENAME COLUMN directory TO visit;

--- a/migrations/0004_rename_visit_to_directory.up.sql
+++ b/migrations/0004_rename_visit_to_directory.up.sql
@@ -1,0 +1,3 @@
+-- Rename visit column to directory
+ALTER TABLE instrument
+RENAME COLUMN visit TO directory;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -70,7 +70,7 @@ pub struct ServeOptions {
 #[derive(Debug, Default, Parser)]
 #[group(requires = "policy_host")]
 pub struct PolicyOptions {
-    /// Beamline Policy Endpoint
+    /// Authorization Policy service
     ///
     /// eg, https://authz.diamond.ac.uk
     #[clap(long = "policy", required = false, env = "NUMTRACKER_AUTH_HOST")]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -46,7 +46,7 @@ pub struct TracingOptions {
 
 #[derive(Debug, Subcommand)]
 pub enum Command {
-    /// Run the server to respond to visit and scan path requests
+    /// Run the server to respond to directory and scan path requests
     Serve(ServeOptions),
     /// Generate the graphql schema
     Schema,
@@ -75,7 +75,7 @@ pub struct PolicyOptions {
     /// eg, https://authz.diamond.ac.uk
     #[clap(long = "policy", required = false, env = "NUMTRACKER_AUTH_HOST")]
     pub policy_host: String,
-    /// The Rego rule used to generate visit access data
+    /// The Rego rule used to generate instrument access data
     ///
     /// eg. v1/data/diamond/policy/session/write_to_beamline_visit
     #[clap(long, required = false, env = "NUMTRACKER_AUTH_ACCESS")]

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -130,13 +130,13 @@ pub enum InvalidPathTemplate {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct VisitTemplate;
+pub struct DirectoryTemplate;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ScanTemplate;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DetectorTemplate;
 
-impl PathSpec for VisitTemplate {
+impl PathSpec for DirectoryTemplate {
     type Field = DirectoryField;
 
     const REQUIRED: &'static [Self::Field] = &[DirectoryField::Instrument, DirectoryField::Visit];
@@ -190,7 +190,7 @@ mod paths_tests {
     use std::fmt::Debug;
 
     use super::{
-        DetectorTemplate, InvalidPathTemplate, PathSpec as _, ScanTemplate, VisitTemplate,
+        DetectorTemplate, DirectoryTemplate, InvalidPathTemplate, PathSpec as _, ScanTemplate,
     };
     use crate::template::{ErrorKind, PathTemplateError};
 
@@ -231,7 +231,7 @@ mod paths_tests {
         #[case] template: &str,
         #[case] err: E,
     ) {
-        let e = VisitTemplate::new_checked(template).unwrap_err();
+        let e = DirectoryTemplate::new_checked(template).unwrap_err();
         assert_eq!(err, e);
     }
 

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -144,7 +144,7 @@ impl PathSpec for DirectoryTemplate {
     const ABSOLUTE: bool = true;
     fn describe() -> &'static str {
         concat!(
-            "A template describing the path to the visit directory for an instrument. ",
+            "A template describing the path to the data directory for a given instrument session. ",
             "It should be an absolute path and contain placeholders for {instrument} and {visit}."
         )
     }
@@ -158,7 +158,7 @@ impl PathSpec for ScanTemplate {
     const ABSOLUTE: bool = false;
     fn describe() -> &'static str {
         concat!(
-            "A template describing the location within a visit directory where the root scan file should be written. ",
+            "A template describing the location within a session data directory where the root scan file should be written. ",
             "It should be a relative path and contain a placeholder for {scan_number} to ensure files are unique."
         )
     }
@@ -175,7 +175,7 @@ impl PathSpec for DetectorTemplate {
     const ABSOLUTE: bool = false;
     fn describe() -> &'static str {
         concat!(
-            "A template describing the location within a visit directory where ",
+            "A template describing the location within a session data directory where ",
             "the data for a given detector should be written",
             "\n\n",
             "It should contain placeholders for {detector} and {scan_number} ",
@@ -227,7 +227,7 @@ mod paths_tests {
     #[case::invalid_path_empty("/data/{}", TemplateErrorType::Empty)]
     #[case::invalid_path_nested("/data/{nes{ted}}", TemplateErrorType::Nested)]
     #[case::invalid_path_unrecognised("/data/{scan_number}", TemplateErrorType::Unrecognised)]
-    fn invalid_visit<E: PartialEq<InvalidPathTemplate> + Debug>(
+    fn invalid_directory<E: PartialEq<InvalidPathTemplate> + Debug>(
         #[case] template: &str,
         #[case] err: E,
     ) {

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -21,7 +21,7 @@ use derive_more::{Display, Error, From};
 use crate::template::{PathTemplate, PathTemplateError};
 
 #[derive(Debug, Display, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum BeamlineField {
+pub enum DirectoryField {
     #[display("year")]
     Year,
     #[display("visit")]
@@ -39,7 +39,7 @@ pub enum ScanField {
     #[display("scan_number")]
     ScanNumber,
     #[display("{_0}")]
-    Beamline(BeamlineField),
+    Directory(DirectoryField),
 }
 
 #[derive(Debug, Display, Clone, Copy, PartialEq, Eq, Hash)]
@@ -54,14 +54,14 @@ pub enum DetectorField {
 #[display("Unrecognised key: {_0:?}")]
 pub struct InvalidKey(#[error(ignore)] String);
 
-impl TryFrom<String> for BeamlineField {
+impl TryFrom<String> for DirectoryField {
     type Error = InvalidKey;
     fn try_from(value: String) -> Result<Self, Self::Error> {
         match value.as_str() {
-            "year" => Ok(BeamlineField::Year),
-            "visit" => Ok(BeamlineField::Visit),
-            "proposal" => Ok(BeamlineField::Proposal),
-            "instrument" => Ok(BeamlineField::Instrument),
+            "year" => Ok(DirectoryField::Year),
+            "visit" => Ok(DirectoryField::Visit),
+            "proposal" => Ok(DirectoryField::Proposal),
+            "instrument" => Ok(DirectoryField::Instrument),
             _ => Err(InvalidKey(value)),
         }
     }
@@ -73,7 +73,7 @@ impl TryFrom<String> for ScanField {
         match value.as_str() {
             "scan_number" => Ok(ScanField::ScanNumber),
             "subdirectory" => Ok(ScanField::Subdirectory),
-            _ => Ok(ScanField::Beamline(BeamlineField::try_from(value)?)),
+            _ => Ok(ScanField::Directory(DirectoryField::try_from(value)?)),
         }
     }
 }
@@ -137,14 +137,14 @@ pub struct ScanTemplate;
 pub struct DetectorTemplate;
 
 impl PathSpec for VisitTemplate {
-    type Field = BeamlineField;
+    type Field = DirectoryField;
 
-    const REQUIRED: &'static [Self::Field] = &[BeamlineField::Instrument, BeamlineField::Visit];
+    const REQUIRED: &'static [Self::Field] = &[DirectoryField::Instrument, DirectoryField::Visit];
 
     const ABSOLUTE: bool = true;
     fn describe() -> &'static str {
         concat!(
-            "A template describing the path to the visit directory for a beamline. ",
+            "A template describing the path to the visit directory for an instrument. ",
             "It should be an absolute path and contain placeholders for {instrument} and {visit}."
         )
     }

--- a/static/service_schema
+++ b/static/service_schema
@@ -35,17 +35,17 @@ type CurrentConfiguration {
 	"""
 	instrument: String!
 	"""
-	The template used to build the path to the visit directory for an instrument
+	The template used to build the path to the data directory for an instrument
 	"""
 	directoryTemplate: String!
 	"""
 	The template used to build the path of a scan file for a data acquisition, relative to the
-	root of the visit directory.
+	root of the data directory.
 	"""
 	scanTemplate: String!
 	"""
 	The template used to build the path of a detector's data file for a data acquisition,
-	relative to the root of the visit directory.
+	relative to the root of the data directory.
 	"""
 	detectorTemplate: String!
 	"""
@@ -84,14 +84,32 @@ type DetectorPath {
 }
 
 """
-A template describing the location within a visit directory where the data for a given detector should be written
+A template describing the location within a session data directory where the data for a given detector should be written
 
 It should contain placeholders for {detector} and {scan_number} to ensure paths are unique between scans and for multiple detectors.
 """
 scalar DetectorTemplate
 
 """
-A template describing the path to the visit directory for an instrument. It should be an absolute path and contain placeholders for {instrument} and {visit}.
+The path to a data directory and the components used to build it
+"""
+type DirectoryPath {
+	"""
+	The instrument session for which this is the data directory
+	"""
+	instrumentSession: String!
+	"""
+	The instrument for which this is the data directory
+	"""
+	instrument: String!
+	"""
+	The absolute path to the data directory
+	"""
+	path: String!
+}
+
+"""
+A template describing the path to the data directory for a given instrument session. It should be an absolute path and contain placeholders for {instrument} and {visit}.
 """
 scalar DirectoryTemplate
 
@@ -105,7 +123,7 @@ type Mutation {
 	"""
 	Generate scan file locations for the next scan
 	"""
-	scan(instrument: String!, visit: String!, sub: Subdirectory): ScanPaths!
+	scan(instrument: String!, instrumentSession: String!, sub: Subdirectory): ScanPaths!
 	"""
 	Add or modify the stored configuration for an instrument
 	"""
@@ -117,10 +135,10 @@ Queries relating to numtracker configurations that have no side-effects
 """
 type Query {
 	"""
-	Get the visit directory information for the given instrument and visit.
+	Get the data directory information for the given instrument and instrument session.
 	This information is not scan specific
 	"""
-	paths(instrument: String!, visit: String!): VisitPath!
+	paths(instrument: String!, instrumentSession: String!): DirectoryPath!
 	"""
 	Get the current configuration for the given instrument
 	"""
@@ -137,9 +155,9 @@ Paths and values related to a specific scan/data collection for an instrument
 """
 type ScanPaths {
 	"""
-	The visit used to generate this scan information. Should be the same as the visit passed in
+	The directory used to generate this scan information.
 	"""
-	visit: VisitPath!
+	directory: DirectoryPath!
 	"""
 	The root scan file for this scan. The path has no extension so that the format can be
 	chosen by the client.
@@ -161,30 +179,12 @@ type ScanPaths {
 }
 
 """
-A template describing the location within a visit directory where the root scan file should be written. It should be a relative path and contain a placeholder for {scan_number} to ensure files are unique.
+A template describing the location within a session data directory where the root scan file should be written. It should be a relative path and contain a placeholder for {scan_number} to ensure files are unique.
 """
 scalar ScanTemplate
 
 
 scalar Subdirectory
-
-"""
-The path to a visit directory and the components used to build it
-"""
-type VisitPath {
-	"""
-	The visit for which this is the visit directory
-	"""
-	visit: String!
-	"""
-	The instrument for which this is the visit directory
-	"""
-	instrument: String!
-	"""
-	The absolute path to the visit directory
-	"""
-	directory: String!
-}
 
 directive @include(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT

--- a/static/service_schema
+++ b/static/service_schema
@@ -1,6 +1,6 @@
 
 """
-Changes that should be made to a beamline's configuration
+Changes that should be made to an instrument's configuration
 """
 input ConfigurationUpdates {
 	"""
@@ -27,15 +27,15 @@ input ConfigurationUpdates {
 }
 
 """
-The current configuration for a beamline
+The current configuration for an instrument
 """
 type CurrentConfiguration {
 	"""
-	The name of the beamline
+	The name of the instrument
 	"""
-	beamline: String!
+	instrument: String!
 	"""
-	The template used to build the path to the visit directory for a beamline
+	The template used to build the path to the visit directory for an instrument
 	"""
 	visitTemplate: String!
 	"""
@@ -50,13 +50,13 @@ type CurrentConfiguration {
 	detectorTemplate: String!
 	"""
 	The latest scan number stored in the DB. This is the last scan number provided by this
-	service but may not reflect the most recent scan number for a beamline if an external
+	service but may not reflect the most recent scan number for an instrument if an external
 	service (eg GDA) has incremented its own number tracker.
 	"""
 	dbScanNumber: Int!
 	"""
-	The highest matching number file for this beamline in the configured tracking directory.
-	May be null if no directory is available for this beamline or if there are no matching
+	The highest matching number file for this instrument in the configured tracking directory.
+	May be null if no directory is available for this instrument or if there are no matching
 	number files.
 	"""
 	fileScanNumber: Int
@@ -100,11 +100,11 @@ type Mutation {
 	"""
 	Generate scan file locations for the next scan
 	"""
-	scan(beamline: String!, visit: String!, sub: Subdirectory): ScanPaths!
+	scan(instrument: String!, visit: String!, sub: Subdirectory): ScanPaths!
 	"""
-	Add or modify the stored configuration for a beamline
+	Add or modify the stored configuration for an instrument
 	"""
-	configure(beamline: String!, config: ConfigurationUpdates!): CurrentConfiguration!
+	configure(instrument: String!, config: ConfigurationUpdates!): CurrentConfiguration!
 }
 
 """
@@ -112,23 +112,23 @@ Queries relating to numtracker configurations that have no side-effects
 """
 type Query {
 	"""
-	Get the visit directory information for the given beamline and visit.
+	Get the visit directory information for the given instrument and visit.
 	This information is not scan specific
 	"""
-	paths(beamline: String!, visit: String!): VisitPath!
+	paths(instrument: String!, visit: String!): VisitPath!
 	"""
-	Get the current configuration for the given beamline
+	Get the current configuration for the given instrument
 	"""
-	configuration(beamline: String!): CurrentConfiguration!
+	configuration(instrument: String!): CurrentConfiguration!
 	"""
-	Get the configurations for all available beamlines
-	Can be filtered to provide one or more specific beamlines
+	Get the configurations for all available instruments
+	Can be filtered to provide one or more specific instruments
 	"""
-	configurations(beamlineFilters: [String!]): [CurrentConfiguration!]!
+	configurations(instrumentFilters: [String!]): [CurrentConfiguration!]!
 }
 
 """
-Paths and values related to a specific scan/data collection for a beamline
+Paths and values related to a specific scan/data collection for an instrument
 """
 type ScanPaths {
 	"""
@@ -141,7 +141,7 @@ type ScanPaths {
 	"""
 	scanFile: String!
 	"""
-	The scan number for this scan. This should be unique for the requested beamline.
+	The scan number for this scan. This should be unique for the requested instrument.
 	"""
 	scanNumber: Int!
 	"""
@@ -172,9 +172,9 @@ type VisitPath {
 	"""
 	visit: String!
 	"""
-	This beamline for which this is the visit directory
+	The instrument for which this is the visit directory
 	"""
-	beamline: String!
+	instrument: String!
 	"""
 	The absolute path to the visit directory
 	"""
@@ -182,7 +182,7 @@ type VisitPath {
 }
 
 """
-A template describing the path to the visit directory for a beamline. It should be an absolute path and contain placeholders for {instrument} and {visit}.
+A template describing the path to the visit directory for an instrument. It should be an absolute path and contain placeholders for {instrument} and {visit}.
 """
 scalar VisitTemplate
 

--- a/static/service_schema
+++ b/static/service_schema
@@ -4,9 +4,9 @@ Changes that should be made to an instrument's configuration
 """
 input ConfigurationUpdates {
 	"""
-	New template used to determine the visit directory
+	New template used to determine the root data directory
 	"""
-	visit: VisitTemplate
+	directory: DirectoryTemplate
 	"""
 	New template used to determine the relative path to the main scan file for a collection
 	"""
@@ -37,7 +37,7 @@ type CurrentConfiguration {
 	"""
 	The template used to build the path to the visit directory for an instrument
 	"""
-	visitTemplate: String!
+	directoryTemplate: String!
 	"""
 	The template used to build the path of a scan file for a data acquisition, relative to the
 	root of the visit directory.
@@ -89,6 +89,11 @@ A template describing the location within a visit directory where the data for a
 It should contain placeholders for {detector} and {scan_number} to ensure paths are unique between scans and for multiple detectors.
 """
 scalar DetectorTemplate
+
+"""
+A template describing the path to the visit directory for an instrument. It should be an absolute path and contain placeholders for {instrument} and {visit}.
+"""
+scalar DirectoryTemplate
 
 
 
@@ -180,11 +185,6 @@ type VisitPath {
 	"""
 	directory: String!
 }
-
-"""
-A template describing the path to the visit directory for an instrument. It should be an absolute path and contain placeholders for {instrument} and {visit}.
-"""
-scalar VisitTemplate
 
 directive @include(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT


### PR DESCRIPTION
- **Replace 'beamline' with 'instrument' where possible**
- **Rename visit template to directory template**
- **Replace references to 'visit' and 'visit directory'**

Fixes #102 