### PR TITLE
Prevent panic when config directory is unavailable

### DIFF
--- a/src/client/config.rs
+++ b/src/client/config.rs
@@ -36,12 +36,16 @@ impl ClientConfiguration {
     }
 
     pub async fn from_default_file() -> Result<Self, ConfigFileError> {
-        let default_file = dirs::config_dir()
-            .expect("Config dir should be known")
-            .join("numtracker")
-            .join("config");
-        match Self::from_file(default_file).await {
-            Err(ConfigFileError::MissingFile) => Ok(Self::default()),
+        let Some(file) = dirs::config_dir().map(|cnf| cnf.join("numtracker").join("config")) else {
+            debug!("Unable to determine default file location - using default config");
+            return Ok(Self::default());
+        };
+
+        match Self::from_file(&file).await {
+            Err(ConfigFileError::MissingFile) => {
+                debug!("Config file {file:?} not present - using default config");
+                Ok(Self::default())
+            }
             res => res,
         }
     }


### PR DESCRIPTION
In some environments (such as within containers), the XDG_CONFIG
directory is not available. In this case, reading the config should
behave as if the file was not present instead of panicking.
