### PR TITLE
Derive Scalar instead of impl InputType for templates

### DIFF
--- a/src/paths.rs
+++ b/src/paths.rs
@@ -88,12 +88,8 @@ impl TryFrom<String> for DetectorField {
     }
 }
 
-#[allow(unused)] // not actually unused: see github.com/rust-lang/rust/issues/128839
-pub trait PathField: TryFrom<String> + Eq + Hash + Display + 'static {}
-impl<F> PathField for F where F: TryFrom<String> + Eq + Hash + Display + 'static {}
-
 pub trait PathSpec {
-    type Field: PathField;
+    type Field: TryFrom<String> + Eq + Hash + Display + 'static;
     const REQUIRED: &'static [Self::Field];
     const ABSOLUTE: bool;
 

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -89,7 +89,7 @@ impl TryFrom<String> for DetectorField {
 }
 
 pub trait PathSpec {
-    type Field: TryFrom<String> + Eq + Hash + Display + 'static;
+    type Field: TryFrom<String> + Eq + Hash + Display + Send + Sync + 'static;
     const REQUIRED: &'static [Self::Field];
     const ABSOLUTE: bool;
 


### PR DESCRIPTION
The types required to implement InputType manually are not considered as
API by async-graphql so often require changes to support what should be
safe updates between patch releases.

Deriving scalar should provide the same interface without having to keep
up with library changes.

