### PR TITLE
Remove unused NumtrackerConfig from db_service

### DIFF
--- a/src/db_service.rs
+++ b/src/db_service.rs
@@ -36,12 +36,6 @@ pub struct SqliteScanPathService {
 }
 
 #[derive(Debug, PartialEq, Eq)]
-pub struct NumtrackerConfig {
-    pub directory: String,
-    pub extension: String,
-}
-
-#[derive(Debug, PartialEq, Eq)]
 struct RawPathTemplate<F>(String, PhantomData<F>);
 
 impl<Spec> RawPathTemplate<Spec>


### PR DESCRIPTION
Config was used when both file extension and directory were configurable
but was left when the directory configuration was removed.
