### PR TITLE
Fix renovate configuration

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,7 +7,7 @@
       {
           "groupName": "patches",
           "matchUpdateTypes": ["patch"],
-          "desription": ["Limit patch updates to once per month"],
+          "description": ["Limit patch updates to once per month"],
           "schedule": ["* * 1 * *"]
       },
       {

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,7 +7,7 @@
       {
           "groupName": "patches",
           "matchUpdateTypes": ["patch"],
-          "desription": "Limit patch updates to once per month",
+          "desription": ["Limit patch updates to once per month"],
           "schedule": ["* * 1 * *"]
       },
       {


### PR DESCRIPTION
Descriptions should be arrays of strings?
