### PR TITLE
Set home to repo URL in helm chart

### DIFF
--- a/helm/numtracker/Chart.yaml
+++ b/helm/numtracker/Chart.yaml
@@ -1,5 +1,6 @@
 apiVersion: v2
 name: numtracker
+home: https://github.com/DiamondLightSource/numtracker
 description: Helm chart to deploy the numtracker service for unifying instrument filenaming
 type: application
 


### PR DESCRIPTION
By adding `home` field to the Helm chart, we allow Renovate to propagate either a link to the chart or release notes into the automated PR it makes.

cite: https://github.com/renovatebot/renovate/blob/39fb4207bc268ea83114b58bc0414339620c7416/lib/modules/datasource/helm/index.ts#L29