### PR TITLE
Update MSRV to 1.86

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ name = "numtracker"
 version = "0.0.0"
 edition = "2021"
 license = "Apache-2.0"
-rust-version = "1.83"
+rust-version = "1.86"
 
 [lints.clippy]
 unwrap_used = "deny"


### PR DESCRIPTION
async-graphql requires a minimum of 1.86 and is the current limiting
factor of the versions we can support.
