### PR TITLE
Include merge_group in CI triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+  merge_group:
 
 env:
   CARGO_TERM_COLOR: always
@@ -75,7 +76,7 @@ jobs:
 
     - name: Install cargo-llvm-cov
       uses: taiki-e/install-action@cargo-llvm-cov
-    
+
     - name: Run tests and generate code coverage
       run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -10,6 +10,8 @@ on:
       - main
   # but all PRs
   pull_request:
+  # ...including once put on a merge queue
+  merge_group:
 
 jobs:
   build:


### PR DESCRIPTION
Support using merge queues to simplify merging multiple PRs without
requiring rebases between merges.
